### PR TITLE
shiung: Remove underscore from card template

### DIFF
--- a/src/components/SpeakerCardColour.astro
+++ b/src/components/SpeakerCardColour.astro
@@ -7,7 +7,7 @@ const { image, name, subtitle } = Astro.props;
       <img src={image} alt={name} class="w-[22rem] h-[22rem] object-cover object-top rounded-full border-pink border-[16px]" />
     </figure>
     <div class="pt-4">
-        <h2 class="text-xl text-center text-pink group-hover:text-white font-autobus sm:text-2xl transition-colors duration-300">{name}_</h2>
+        <h2 class="text-xl text-center text-pink group-hover:text-white font-autobus sm:text-2xl transition-colors duration-300">{name}</h2>
         <p class="mt-1 text-xs text-center text-pink group-hover:text-yellow font-autobus sm:text-sm transition-colors duration-300">{subtitle}</p>
     </div>
   </button>

--- a/src/components/SponsorList.astro
+++ b/src/components/SponsorList.astro
@@ -12,7 +12,7 @@ const { sponsors } = Astro.props as { sponsors: Sponsor[] };
 <div class="flex flex-col items-center justify-center bg-pink pb-8 border-t-8 border-black-900">
   <div class="bg-black-900 px-16 py-4 [clip-path:polygon(0%_0%,100%_0%,98%_90%,3%_80%)]">
     <h1 class="font-bold font-autobus text-white text-xl sm:text-2xl">
-      Our Sponsors_
+      Our Sponsors
     </h1>
   </div>
 </div>
@@ -23,7 +23,7 @@ const { sponsors } = Astro.props as { sponsors: Sponsor[] };
       sponsor.header === "Gold Sponsor" ? (
         <>
           <h3 class="mt-8 text-yellow font-autobus text-2xl">
-            {sponsor.header}_
+            {sponsor.header}
           </h3>
           <div class="flex flex-wrap justify-center gap-2 mt-4">
             {sponsor.sponsor.map((s) => (
@@ -33,7 +33,7 @@ const { sponsors } = Astro.props as { sponsors: Sponsor[] };
         </>
       ) : (
         <div class="w-11/12 text-center my-4 pb-5">
-          <h3 class="mt-8 text-yellow font-autobus">{sponsor.header}_</h3>
+          <h3 class="mt-8 text-yellow font-autobus">{sponsor.header}</h3>
           <div class="flex flex-wrap justify-center gap-2 mt-4">
             {sponsor.sponsor.map((s) => (
               <SponsorCard img={s.img} alt={s.alt} link={s.link} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,18 +39,18 @@ import { AllSpeakers, KeyNoteSpeakers } from "../speakerLists";
         />
       </div>
     </a>
-    
+
   </div>
     <h3 class="mt-16 text-white font-bold text-xl sm:text-4xl font-autobus">
-      Keynote Speakers_
+      Keynote Speakers
     </h3>
     <SpeakerCarousel speakers={KeyNoteSpeakers} />
     <h3 class="mt-8 text-white font-bold text-xl sm:text-4xl font-autobus">
-      Speakers_
+      Speakers
     </h3>
-    <SpeakerCarousel speakers={AllSpeakers} /> 
+    <SpeakerCarousel speakers={AllSpeakers} />
     <Countdown />
-    
+
     <a href={register_link} class="mt-8 w-72 mb-36" target="_blank">
       <div class="relative">
         <img class="absolute" src="/assets/Register_Mouse_Up.png" />
@@ -61,7 +61,7 @@ import { AllSpeakers, KeyNoteSpeakers } from "../speakerLists";
       </div>
     </a>
   </div>
-  
+
   <SponsorList sponsors={SponsorLists} />
   <PartnerList partners={PartnerLists} />
 </BaseLayout>


### PR DESCRIPTION
Remove underscores from names and headers in the template.

## Before

![image](https://github.com/user-attachments/assets/6e847a56-d9be-4b06-8955-80513d4a896f)

## After

![image](https://github.com/user-attachments/assets/f796bb60-1aa5-4a4f-bfe0-c0ccce8181aa)
